### PR TITLE
adds npmignore as it is not bundling when published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+*.swo
+*.swp
+.DS_Store
+.browser-preferences/
+.git
+.github
+.idea
+.travis.yml
+.vscode
+node_modules
+src
+yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-state-management",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-state-management",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-state-management",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Carbon - State Management",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Description
Fixes the publish issue where `lib` and `node_modules` directories were not present in published package